### PR TITLE
bug fix: Used deprecated arguments in datastructures.py

### DIFF
--- a/mindwalc/datastructures.py
+++ b/mindwalc/datastructures.py
@@ -129,16 +129,16 @@ class Graph(object):
                 o = str(o)
 
                 if isinstance(s, rdflib.term.BNode):
-                    s_v = Vertex(str(s), wildcard=True)
+                    s_v = Vertex(str(s))
                 elif isinstance(s, rdflib.term.Literal):
-                    s_v = Vertex(str(s), literal=True)
+                    s_v = Vertex(str(s))
                 else:
                     s_v = Vertex(str(s))
                     
                 if isinstance(o, rdflib.term.BNode):
-                    o_v = Vertex(str(o), wildcard=True)
+                    o_v = Vertex(str(o))
                 elif isinstance(s, rdflib.term.Literal):
-                    o_v = Vertex(str(o), literal=True)
+                    o_v = Vertex(str(o))
                 else:
                     o_v = Vertex(str(o))
                     


### PR DESCRIPTION
Hey,

I recently came across a few lines using deprecated arguments that no longer exist, as far as I can see.

It is about the following lines:

https://github.com/IBCNServices/MINDWALC/blob/214c8cc26cce698491f7303321c82bd2b8b9d02d/mindwalc/datastructures.py#L132 
https://github.com/IBCNServices/MINDWALC/blob/214c8cc26cce698491f7303321c82bd2b8b9d02d/mindwalc/datastructures.py#L134 
https://github.com/IBCNServices/MINDWALC/blob/214c8cc26cce698491f7303321c82bd2b8b9d02d/mindwalc/datastructures.py#L139 
https://github.com/IBCNServices/MINDWALC/blob/214c8cc26cce698491f7303321c82bd2b8b9d02d/mindwalc/datastructures.py#L141

In these line, we create new Vertex Objects and pass the arguments wildcard=True or literal=True as second argument. 
Since these arguments do not exist in the `__ini__` of the Vertex class, this causes errors like:

> TypeError: Vertex.__init__() got an unexpected keyword argument 'wildcard' 
 
So i corrected these lines accordingly. 
is everyone fine with it?

Best regards
Max