### PR TITLE
relation-tail-merging-1.0

### DIFF
--- a/mindwalc/datastructures.py
+++ b/mindwalc/datastructures.py
@@ -120,7 +120,7 @@ class Graph(object):
         return neighborhood
 
     @staticmethod
-    def rdflib_to_graph(rdflib_g, label_predicates=[], relation_tail_merging=True):
+    def rdflib_to_graph(rdflib_g, label_predicates=[], relation_tail_merging=False):
         '''
         Converts an rdflib graph to a Graph object.
         During the conversion, a multi-relation graph (head)-[relation]->(tail) (aka subject, predicate, object)is converted to a non-relational graph.
@@ -485,8 +485,12 @@ if __name__ == "__main__":
     kg = Graph.rdflib_to_graph(g, label_predicates=label_predicates, relation_tail_merging=False)
     #kg.graph_to_neo4j(password=sys.argv[1])
     verts_a = len(kg.vertices)
-    print(f"generated graph using relation-to-node-convertion has {str(float(verts_a)/1000).replace('.', ',')} vertices")
-    clf = MINDWALCTree(path_max_depth=6, min_samples_leaf=1, max_tree_depth=None, n_jobs=1)
+    rels_a = len(kg.transition_matrix)
+
+    print(f"generated graph using relation-to-node-convertion has "
+          f"{str(float(verts_a)/1000).replace('.', ',')} vertices")
+    print(f"and {str(float(rels_a)/1000).replace('.', ',')} relations")
+    clf = MINDWALCTree(path_max_depth=8, min_samples_leaf=1, max_tree_depth=None, n_jobs=1)
     clf.fit(kg, train_entities, train_labels)
     preds = clf.predict(kg, test_entities)
     print(f"accuracy: {accuracy_score(test_labels, preds)}")
@@ -496,14 +500,17 @@ if __name__ == "__main__":
     # convert to non relational graphs using relation-tail-merging:
     kg = Graph.rdflib_to_graph(g, label_predicates=label_predicates, relation_tail_merging=True)
     verts_b = len(kg.vertices)
-    print(
-        f"generated graph using relation_tail_merging has {str(float(verts_b)/1000).replace('.', ',')} vertices")
-    clf = MINDWALCTree(path_max_depth=6, min_samples_leaf=1, max_tree_depth=None, n_jobs=1)
+    rels_b = len(kg.transition_matrix)
+    print(f"generated graph using relation_tail_merging has "
+          f"{str(float(verts_b)/1000).replace('.', ',')} vertices")
+    print(f"and {str(float(rels_b)/1000).replace('.', ',')} relations")
+    clf = MINDWALCTree(path_max_depth=8, min_samples_leaf=1, max_tree_depth=None, n_jobs=1)
     clf.fit(kg, train_entities, train_labels)
     preds = clf.predict(kg, test_entities)
     print(f"accuracy: {accuracy_score(test_labels, preds)}")
 
-    print(f"\nrelation_tail_merging reduced the number of vertices by {verts_a - verts_b} ({round((verts_a - verts_b)/verts_a *100, 0)} %)")
+    print(f"\nrelation-tail merging reduced the number of vertices by {verts_a - verts_b} ({round((verts_a - verts_b)/verts_a *100, 2)} %)")
+    print(f"relation-tail merging reduced the number of relations by {rels_a - rels_b} ({round((rels_a - rels_b)/rels_a *100, 2)} %)")
 
 
 

--- a/mindwalc/datastructures.py
+++ b/mindwalc/datastructures.py
@@ -471,6 +471,7 @@ if __name__ == "__main__":
     g = rdflib.Graph()
     g.parse(rdf_file, format=_format)
     skip_literals = True
+    path_max_depth = 8
 
     # load train data:
     train_file = 'data/AIFB/AIFB_test.tsv'
@@ -497,8 +498,10 @@ if __name__ == "__main__":
     print(f"generated graph using relation-to-node-convertion has "
           f"{str(float(verts_a)/1000).replace('.', ',')} vertices")
     print(f"and {str(float(rels_a)/1000).replace('.', ',')} relations")
-    clf = MINDWALCTree(path_max_depth=8, min_samples_leaf=1, max_tree_depth=None, n_jobs=1)
+    clf = MINDWALCTree(path_max_depth=path_max_depth, min_samples_leaf=1, max_tree_depth=None, n_jobs=1)
     clf.fit(kg, train_entities, train_labels)
+    clf.tree_.visualize("./data/AIFB/aifb_MINDWALCtree1", _view=False,
+                        meta_infos="Training method: MINDWALCTree, relation-to-node-converted graph")
     preds = clf.predict(kg, test_entities)
     print(f"accuracy: {accuracy_score(test_labels, preds)}")
 
@@ -512,8 +515,10 @@ if __name__ == "__main__":
     print(f"generated graph using relation_tail_merging has "
           f"{str(float(verts_b)/1000).replace('.', ',')} vertices")
     print(f"and {str(float(rels_b)/1000).replace('.', ',')} relations")
-    clf = MINDWALCTree(path_max_depth=8, min_samples_leaf=1, max_tree_depth=None, n_jobs=1)
+    clf = MINDWALCTree(path_max_depth=path_max_depth, min_samples_leaf=1, max_tree_depth=None, n_jobs=1)
     clf.fit(kg, train_entities, train_labels)
+    clf.tree_.visualize("./data/AIFB/aifb_MINDWALCtree2", _view=False,
+                        meta_infos="Training method: MINDWALCTree, relation-tail merged graph")
     preds = clf.predict(kg, test_entities)
     print(f"accuracy: {accuracy_score(test_labels, preds)}")
 

--- a/mindwalc/datastructures.py
+++ b/mindwalc/datastructures.py
@@ -471,7 +471,7 @@ if __name__ == "__main__":
     g = rdflib.Graph()
     g.parse(rdf_file, format=_format)
     skip_literals = True
-    path_max_depth = 8
+    path_max_depth = 10
 
     # load train data:
     train_file = 'data/AIFB/AIFB_test.tsv'
@@ -493,11 +493,10 @@ if __name__ == "__main__":
                                skip_literals=skip_literals)
     #kg.graph_to_neo4j(password=sys.argv[1])
     verts_a = len(kg.vertices)
-    rels_a = len(kg.transition_matrix)
-
+    edges_a = sum([len(x) for x in kg.transition_matrix.values()])
     print(f"generated graph using relation-to-node-convertion has "
           f"{str(float(verts_a)/1000).replace('.', ',')} vertices")
-    print(f"and {str(float(rels_a)/1000).replace('.', ',')} relations")
+    print(f"and {str(float(edges_a) / 1000).replace('.', ',')} edges")
     clf = MINDWALCTree(path_max_depth=path_max_depth, min_samples_leaf=1, max_tree_depth=None, n_jobs=1)
     clf.fit(kg, train_entities, train_labels)
     clf.tree_.visualize("./data/AIFB/aifb_MINDWALCtree1", _view=False,
@@ -511,10 +510,10 @@ if __name__ == "__main__":
     kg = Graph.rdflib_to_graph(g, label_predicates=label_predicates, relation_tail_merging=True,
                                skip_literals=skip_literals)
     verts_b = len(kg.vertices)
-    rels_b = len(kg.transition_matrix)
+    edges_b = sum([len(x) for x in kg.transition_matrix.values()])
     print(f"generated graph using relation_tail_merging has "
           f"{str(float(verts_b)/1000).replace('.', ',')} vertices")
-    print(f"and {str(float(rels_b)/1000).replace('.', ',')} relations")
+    print(f"and {str(float(edges_b) / 1000).replace('.', ',')} edges")
     clf = MINDWALCTree(path_max_depth=path_max_depth, min_samples_leaf=1, max_tree_depth=None, n_jobs=1)
     clf.fit(kg, train_entities, train_labels)
     clf.tree_.visualize("./data/AIFB/aifb_MINDWALCtree2", _view=False,
@@ -523,7 +522,5 @@ if __name__ == "__main__":
     print(f"accuracy: {accuracy_score(test_labels, preds)}")
 
     print(f"\nrelation-tail merging reduced the number of vertices by {verts_a - verts_b} ({round((verts_a - verts_b)/verts_a *100, 2)} %)")
-    print(f"relation-tail merging reduced the number of relations by {rels_a - rels_b} ({round((rels_a - rels_b)/rels_a *100, 2)} %)")
-
-
+    print(f"relation-tail merging reduced the number of edges by {edges_a - edges_b} ({round((edges_a - edges_b) / edges_a * 100, 2)} %)")
 

--- a/mindwalc/tree_builder.py
+++ b/mindwalc/tree_builder.py
@@ -47,8 +47,9 @@ class MINDWALCMixin():
         """Generates an iterable with all possible walk candidates."""
         # Generate a set of all possible (vertex, depth) combinations
         walks = set()
-        for d in range(2, self.path_max_depth + 1, 2):
-            for neighborhood in neighborhoods:
+        #for d in range(2, self.path_max_depth + 1, 2):
+        for neighborhood in neighborhoods:
+            for d in neighborhood.depth_map.keys():
                 for vertex in neighborhood.depth_map[d]:
                     walks.add((vertex, d))
 


### PR DESCRIPTION
Hi,

I added a new method to convert a multi-relational rdf-graph file into a non-relational graph of type `datastructures::Graph`, called _"relation-tail merging"_. 
It can be used by calling the `datastructures::Graph::rdflib_to_graph()` method with the new input-parameter `relation_tail_merging=True`. 

The process of relation-tail merging tries to solve the issue that predicate-nodes often carry little to no information (which is why these candidates are usually skipped during walk mining). 
Relation_tail_merging works as follows (is also explained in our corresponding paper, which is currently under review): 

First, the next tail node is  selected, t, as well as a set of nr relations of identical type, r, where the topological  form (*)-r->(t) is given. The process of relation-tail merging then involves inserting  a new node, rt, so that (*)-r->(t) turns into (*)-->(rt)-->(t). The new directional  edges, -->, are now typeless, and the new inserted node, rt, represents a "relation-modified" node and is named accordingly in the form <type_of_r>_<name_of_t>.

To implement this method, i changed the  `datastructures::Graph::rdflib_to_graph()` method accordingly and i also applied a small change to the function `MINDWALCMixin::_generate_candidates()`, so that, if we use a relation-tail merged graph, MINDWALC does also collect walks with odd depths, so that also (rt) nodes are considered during candidate collection.

I also added a mew function to the datastructures::Graph class, called graph_to_neo4j(). This method can load a given datastructures::Graph instance into a running and empty neo4j database. This can be useful to investigate our graph using the neo4j desktop app. 